### PR TITLE
UIWRKFLOW-3

### DIFF
--- a/src/components/ListTable/ListTable.tsx
+++ b/src/components/ListTable/ListTable.tsx
@@ -9,7 +9,7 @@ import { ITEMS_VISIBLE_COLUMNS, CURRENT_PAGE_OFFSET_KEY, PAGINATION_AMOUNT } fro
 import { IListProperties } from '../../interfaces';
 import { useLists, usePrevious } from '../../hooks';
 
-export const ListTable: FC<IListProperties> = ({ activeFilters, setTotalRecords = noop }) => {
+export const ListTable: FC<IListProperties> = ({ path, activeFilters, setTotalRecords = noop }) => {
   const [storedCurrentPageOffset] = useLocalStorage<number>(CURRENT_PAGE_OFFSET_KEY, 0);
   const [recordIds, setRecordIds] = useState<string[]>([]);
 
@@ -37,7 +37,7 @@ export const ListTable: FC<IListProperties> = ({ activeFilters, setTotalRecords 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeFilters]);
 
-  const { listsData, isLoading } = useLists({ filters: activeFilters, size: pagination?.limit, offset: pagination?.offset });
+  const { listsData, isLoading } = useLists(path, { query: "", filters: activeFilters, size: pagination?.limit, offset: pagination?.offset });
 
   useEffect(() => {
     if (listsData?.content?.length) {

--- a/src/components/ListTable/ListTable.tsx
+++ b/src/components/ListTable/ListTable.tsx
@@ -40,8 +40,8 @@ export const ListTable: FC<IListProperties> = ({ path, activeFilters, setTotalRe
   const { listsData, isLoading } = useLists(path, { query: "", limit: pagination?.limit, offset: pagination?.offset });
 
   useEffect(() => {
-    if (listsData?.content?.length) {
-      setRecordIds(listsData?.content.map(({ id }) => id));
+    if (listsData?.workflows) {
+      setRecordIds(listsData?.workflows.map(({ id }) => id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listsData]);
@@ -54,8 +54,9 @@ export const ListTable: FC<IListProperties> = ({ path, activeFilters, setTotalRe
     );
   }
 
-  const { totalRecords = 0, totalPages } = listsData ?? {};
-  let { content } = listsData ?? {};
+  const { totalRecords = 0 } = listsData ?? {};
+  const { workflows } = listsData ?? {};
+  const totalPages = 1;
 
   setTotalRecords(totalRecords);
 
@@ -63,7 +64,7 @@ export const ListTable: FC<IListProperties> = ({ path, activeFilters, setTotalRe
     <>
       <MultiColumnList
         interactive
-        contentData={content}
+        contentData={workflows}
         visibleColumns={ITEMS_VISIBLE_COLUMNS}
         formatter={listTableResultFormatter}
         pagingType={null}

--- a/src/components/ListTable/ListTable.tsx
+++ b/src/components/ListTable/ListTable.tsx
@@ -37,7 +37,7 @@ export const ListTable: FC<IListProperties> = ({ path, activeFilters, setTotalRe
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeFilters]);
 
-  const { listsData, isLoading } = useLists(path, { query: "", filters: activeFilters, size: pagination?.limit, offset: pagination?.offset });
+  const { listsData, isLoading } = useLists(path, { query: "", limit: pagination?.limit, offset: pagination?.offset });
 
   useEffect(() => {
     if (listsData?.content?.length) {

--- a/src/components/ListTable/helpers/formatters.ts
+++ b/src/components/ListTable/helpers/formatters.ts
@@ -2,7 +2,7 @@ import { ITEM_COLUMNS_NAME } from '../../../constants';
 import { IItemRecord } from '../../../interfaces';
 import { t } from '../../../utilities';
 
-export const listTableResultFormatter: Record<string, (item: IItemRecord) => any> = {
+export const listTableResultFormatter: Record<string, (item: any) => any> = {
   [ITEM_COLUMNS_NAME.ID]: (item) => { item.id },
   [ITEM_COLUMNS_NAME.NAME]: (item) => { item.name },
   [ITEM_COLUMNS_NAME.DESCRIPTION]: (item) => { item.description },

--- a/src/components/ListTable/helpers/formatters.ts
+++ b/src/components/ListTable/helpers/formatters.ts
@@ -6,6 +6,6 @@ export const listTableResultFormatter: Record<string, (item: IItemRecord) => any
   [ITEM_COLUMNS_NAME.ID]: (item) => { item.id },
   [ITEM_COLUMNS_NAME.NAME]: (item) => { item.name },
   [ITEM_COLUMNS_NAME.DESCRIPTION]: (item) => { item.description },
-  [ITEM_COLUMNS_NAME.VERSION]: (item) => { item.version },
+  [ITEM_COLUMNS_NAME.VERSIONTAG]: (item) => { item.versionTag },
   [ITEM_COLUMNS_NAME.ACTIVE]: (item) => { t(item.active ? 'workflows.item.active' : 'workflows.item.inactive') }
 };

--- a/src/components/ListTable/helpers/mappers.ts
+++ b/src/components/ListTable/helpers/mappers.ts
@@ -6,6 +6,6 @@ export const listTableMapping: Record<string, ReactNode> = {
   [ITEM_COLUMNS_NAME.ID]: t('workflows.item.id'),
   [ITEM_COLUMNS_NAME.NAME]: t('workflows.item.name'),
   [ITEM_COLUMNS_NAME.DESCRIPTION]: t('workflows.item.description'),
-  [ITEM_COLUMNS_NAME.VERSION]: t('workflows.item.version'),
+  [ITEM_COLUMNS_NAME.VERSIONTAG]: t('workflows.item.versionTag'),
   [ITEM_COLUMNS_NAME.ACTIVE]: t('workflows.item.active'),
 };

--- a/src/constants/Base.ts
+++ b/src/constants/Base.ts
@@ -1,6 +1,5 @@
 export const PROJECT_NAMESPACE = 'ui-workflow';
 
-export const HOME_PAGE_SHORT = 'workflow'
 export const HOME_PAGE_URL = '/workflow';
 export const CREATE_PATH = '/create';
 

--- a/src/constants/Lists.ts
+++ b/src/constants/Lists.ts
@@ -8,7 +8,7 @@ export const ITEM_COLUMNS_NAME = {
   ID: 'id',
   NAME: 'name',
   DESCRIPTION: 'description',
-  VERSION: 'version',
+  VERSIONTAG: 'versionTag',
   ACTIVE: 'active',
 };
 

--- a/src/constants/Views.ts
+++ b/src/constants/Views.ts
@@ -23,3 +23,8 @@ export const DEFAULT_FILTERS: stringMap = {
   'create': {
   },
 };
+
+export const PATH: stringMap = {
+  'browse': 'workflow/search',
+  'create': 'workflow/create'
+};

--- a/src/constants/Views.ts
+++ b/src/constants/Views.ts
@@ -25,6 +25,6 @@ export const DEFAULT_FILTERS: stringMap = {
 };
 
 export const PATH: stringMap = {
-  'browse': 'workflow/search',
-  'create': 'workflow/create'
+  'browse': 'workflows/search',
+  'create': 'workflows/create'
 };

--- a/src/hooks/useFilterConfig/useFilterConfigBrowse.ts
+++ b/src/hooks/useFilterConfig/useFilterConfigBrowse.ts
@@ -2,7 +2,7 @@ import { useLists } from '../useLists';
 import { t } from '../../utilities';
 
 export const useFilterConfigBrowse = () => {
-  const { listsData = [], isLoading }: any = useLists();
+  const { listsData = [], isLoading }: any = useLists("");
 
   const filterConfig: any[] = [
     {

--- a/src/hooks/useFilterConfig/useFilterConfigCreate.ts
+++ b/src/hooks/useFilterConfig/useFilterConfigCreate.ts
@@ -2,7 +2,7 @@ import { useLists } from '../useLists';
 import { t } from '../../utilities';
 
 export const useFilterConfigCreate = () => {
-  const { listsData = [], isLoading }: any = useLists();
+  const { listsData = [], isLoading }: any = useLists("");
 
   const filterConfig: any[] = [
   ];

--- a/src/hooks/useLists/useLists.ts
+++ b/src/hooks/useLists/useLists.ts
@@ -1,13 +1,13 @@
 import { useQuery } from 'react-query';
 import { useOkapiKy } from '@folio/stripes/core';
 
-import { HOME_PAGE_SHORT, POLLING_STATUS_DELAY } from '../../constants';
+import { POLLING_STATUS_DELAY } from '../../constants';
 import { IListRequest, IListResponse, IItemRecord } from '../../interfaces';
 import { buildListUrl } from '../../utilities';
 
-export const useLists = (request?: IListRequest) => {
+export const useLists = (path: string, request?: IListRequest) => {
   const ky = useOkapiKy();
-  const url = buildListUrl(HOME_PAGE_SHORT, request);
+  const url = buildListUrl(path, request);
 
   const { data, isLoading, error } = useQuery<IListResponse<IItemRecord[]>, Error>(
     {

--- a/src/interfaces/lists/IListProperties.ts
+++ b/src/interfaces/lists/IListProperties.ts
@@ -1,4 +1,5 @@
 export interface IListProperties {
+  path: string,
   activeFilters: string[],
   setTotalRecords: (totalRecords: number) => void
 }

--- a/src/interfaces/lists/IListRequest.ts
+++ b/src/interfaces/lists/IListRequest.ts
@@ -1,7 +1,5 @@
 export interface IListRequest {
   query?: string,
-  filters?: Array<string>,
-  idsToTrack?: Array<string>,
-  size?: number,
+  limit?: number,
   offset?: number
 }

--- a/src/interfaces/lists/IListRequest.ts
+++ b/src/interfaces/lists/IListRequest.ts
@@ -1,4 +1,5 @@
 export interface IListRequest {
+  query?: string,
   filters?: Array<string>,
   idsToTrack?: Array<string>,
   size?: number,

--- a/src/interfaces/lists/IListResponse.ts
+++ b/src/interfaces/lists/IListResponse.ts
@@ -2,15 +2,6 @@ import { IPagination } from './IPagination';
 import { ISort } from './ISort';
 
 export interface IListResponse<T> {
-  content: T;
-  pageable: IPagination;
-  totalPages: number;
+  workflows: T;
   totalRecords: number;
-  last: boolean;
-  size: number;
-  number: number;
-  sort: ISort;
-  numberOfElements: number;
-  first: boolean;
-  empty: boolean;
 }

--- a/src/interfaces/records/IItemRecord.ts
+++ b/src/interfaces/records/IItemRecord.ts
@@ -2,6 +2,6 @@ export interface IItemRecord {
   id: string;
   name: string;
   description: string;
-  versionTag: number;
+  versionTag: string;
   active: boolean;
 }

--- a/src/interfaces/records/IItemRecord.ts
+++ b/src/interfaces/records/IItemRecord.ts
@@ -2,6 +2,6 @@ export interface IItemRecord {
   id: string;
   name: string;
   description: string;
-  version: number;
+  versionTag: number;
   active: boolean;
 }

--- a/src/utilities/buildListsUrl/buildListUrl.ts
+++ b/src/utilities/buildListsUrl/buildListUrl.ts
@@ -1,7 +1,7 @@
 import { STATUS_ACTIVE, STATUS_INACTIVE } from '../../constants';
 
 export const buildListUrl = (url: string, request?: any) => {
-  const { filters, offset, size, idsToTrack } = request || {};
+  const { query, filters, offset, size, idsToTrack } = request || {};
   const params = new URLSearchParams();
   const entityTypeIdsArray = [];
 
@@ -20,6 +20,8 @@ export const buildListUrl = (url: string, request?: any) => {
   const entityTypeIdsString = entityTypeIdsArray.join(',');
 
   if (entityTypeIdsString) params.append('entityTypeIds', entityTypeIdsString);
+
+  if (typeof query == 'string') params.append('query', query);
 
   // If tracking IDs, don't use offset
   if (offset && !idsToTrack?.length) params.append('offset', offset.toString());

--- a/src/utilities/buildListsUrl/buildListUrl.ts
+++ b/src/utilities/buildListsUrl/buildListUrl.ts
@@ -1,42 +1,14 @@
 import { STATUS_ACTIVE, STATUS_INACTIVE } from '../../constants';
 
 export const buildListUrl = (url: string, request?: any) => {
-  const { query, filters, offset, size, idsToTrack } = request || {};
+  const { query, limit, offset } = request || {};
   const params = new URLSearchParams();
-  const entityTypeIdsArray = [];
-
-  if (filters?.length) {
-    if (filters.includes(STATUS_ACTIVE) && !filters.includes(STATUS_INACTIVE)) {
-      params.append('active', 'true');
-    } else if (filters.includes(STATUS_INACTIVE) && !filters.includes(STATUS_ACTIVE)) {
-      params.append('active', 'false');
-    }
-
-    for (const filter of filters) {
-      entityTypeIdsArray.push(filter);
-    }
-  }
-
-  const entityTypeIdsString = entityTypeIdsArray.join(',');
-
-  if (entityTypeIdsString) params.append('entityTypeIds', entityTypeIdsString);
 
   if (typeof query == 'string') params.append('query', query);
-
-  // If tracking IDs, don't use offset
-  if (offset && !idsToTrack?.length) params.append('offset', offset.toString());
-
-  if (size) params.append('size', size.toString());
-
-  if (idsToTrack?.length) {
-    params.append('ids', idsToTrack.join(','));
-  }
+  if (offset) params.append('offset', offset.toString());
+  if (limit) params.append('limit', limit.toString());
 
   const paramString = params.toString();
 
-  if (paramString) {
-    return url + `?${paramString}`;
-  }
-
-  return url;
+  return paramString ? url + `?${paramString}` : url;
 }

--- a/src/views/browse/BrowseView.tsx
+++ b/src/views/browse/BrowseView.tsx
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 
 import { FilterMenu, FilterPane, ListTable, WorkflowIcon } from '../../components';
 import { getFilters } from '../../hooks';
-import { DEFAULT_FILTERS, FILTER_APPLIED_KEY, VIEW } from '../../constants';
+import { DEFAULT_FILTERS, FILTER_APPLIED_KEY, PATH, VIEW } from '../../constants';
 import { IView } from '../../interfaces';
 import { t } from '../../utilities';
 
@@ -23,7 +23,7 @@ export const BrowseView: FunctionComponent<IView> = (props: any) => {
       <Paneset>
         <FilterPane view={VIEW.BROWSE} />
         <Pane defaultWidth="fill" paneTitle={ t('title.workflowList') } appIcon={<WorkflowIcon />} firstMenu={<FilterMenu />} lastMenu={actionMenu}>
-          <ListTable activeFilters={activeFilters} setTotalRecords={setTotalRecords} />
+          <ListTable path={PATH[VIEW.BROWSE]} activeFilters={activeFilters} setTotalRecords={setTotalRecords} />
         </Pane>
       </Paneset>
     </ErrorBoundary>

--- a/translations/ui-workflow/en.json
+++ b/translations/ui-workflow/en.json
@@ -16,5 +16,5 @@
   "workflows.item.inactive": "Inactive",
   "workflows.item.item": "Item",
   "workflows.item.name": "Name",
-  "workflows.item.version": "version"
+  "workflows.item.versionTag": "Version"
 }


### PR DESCRIPTION
This adds a path parameter to allow for custom paths to be used.

This removes the no longer needed `HOME_PAGE_SHORT` constant.
A `PATH` map is used to contain the search paths for each view.

The `query` is required and so use a `typeof` check so that an empty string may also be passed.
This allows the `buildListUrl` to be used on more than just a search path that requires `query`.

The search end point does not support ids nor does it support filters.
Remove this code for the time being.

The CQL query is the filter and there may need to be further design considerations regarding how to implement CQL query generation from the UI perspective.
The current design just provides an empty CQL query.

The rest of the filter code is left in place to either be amended, replaced, or deleted at some future date.

The mod-workflow endpoint is `/workflows` and not `/workflows`.

The workflow column name is `versionTag` and not `version`.
I cannot simply have the properties be `VERSION` but the detailed value be `versionTag` as this somehow causes compilation problems.
Refactor every `VERSION` to `VERSIONTAG`.
Refactor every `version` to `versionTag`.

This update the `en.json` and leaves the other languages alone.
This is done because I expect the automated processes will create the language translations for us like it previously has done.


