### PR TITLE
UIWRKFLOW-7: Should the JSON parse fail, then use the error reason.

### DIFF
--- a/src/hooks/useUpload/useUploadMultipart.ts
+++ b/src/hooks/useUpload/useUploadMultipart.ts
@@ -23,9 +23,13 @@ export const useUploadMultipart = () => {
       let reason = error.toString();
 
       if (error?.name === 'HTTPError') {
-        const errorJson = await error.response.json();
-        if (errorJson?.errors?.length > 0) {
-          reason = errorJson.errors[0]?.code + ' ' + errorJson.errors[0]?.message;
+        try {
+          const errorJson = await error.response.json();
+          if (errorJson?.errors?.length > 0) {
+            reason = errorJson.errors[0]?.code + ' ' + errorJson.errors[0]?.message;
+          }
+        } catch (error: any) {
+          // If error.response.json() fails, then do nothing.
         }
       }
 


### PR DESCRIPTION
A `try..catch..` is required so that a nastier full screen stripes error is avoided.

This behavior can be observed by not having a back end server running.

A cleaner error is presented with this change.