### PR TITLE
UIWRKFLOW-19: The DropdownMenu requires that the open be specified when onToggle is specified.

### DIFF
--- a/src/components/CreateActionMenu/CreateActionMenu.tsx
+++ b/src/components/CreateActionMenu/CreateActionMenu.tsx
@@ -20,7 +20,7 @@ export const CreateActionMenu: React.FC<ICreateActionMenu> = ({ importDetail, st
 
   return (
     <Dropdown id='menu-actions-create-dropdown' label={ t('button.actions') } buttonProps={{ buttonStyle: 'primary', marginBottom0: true }}>
-      <DropdownMenu data-role='menu' aria-label={ t('create.action.menu') } onToggle={onToggle} open={open}>
+      <DropdownMenu data-role='menu' aria-label={ t('create.action.menu') } onToggle={onToggle} open>
         <><Button
           data-role='menuitem'
           buttonStyle='dropdownItem'


### PR DESCRIPTION
resolves [UIWRKFLOW-19](https://folio-org.atlassian.net/browse/UIWRKFLOW-19).

This is a continuation of the commit 248b82caded69a706845fc740dea52b379b31a9c. The first approach set the open attribute value to the `open` variable. This allowed for the module to compile but the drown downs became non-functional.

Simply adding the presence of the open attribute with no value assigned appears to allow for the drop down to work as expected.