### PR TITLE
UIWRKFLOW-21: Fix typo in permissions name 'workflow.tasks.all'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
           "workflow.actions.all",
           "workflow.events.all",
           "workflow.triggers.all",
-          "workflow.tsks.all",
+          "workflow.tasks.all",
           "workflow.workflows.all"
         ],
         "visible": true


### PR DESCRIPTION
[UIWRKFLOW-21](https://folio-org.atlassian.net/browse/UIWRKFLOW-21)