### PR TITLE
UIWRKFLOW-13: Change workflow detail pane to be full screen.

### DIFF
--- a/src/components/ItemRecordDetailPane/ItemRecordDetailPane.tsx
+++ b/src/components/ItemRecordDetailPane/ItemRecordDetailPane.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Accordion, AccordionSet, Button, Col, ErrorBoundary, Pane, Row } from '@folio/stripes/components';
+import { Accordion, AccordionSet, Button, Col, ErrorBoundary, Layer, Pane, Row } from '@folio/stripes/components';
 import { noop } from 'lodash';
 
 import { BooleanItemValue, BooleanMapItemValue, NodesItemValue, NumberItemValue, StringItemValue } from '../../components';
@@ -12,13 +12,9 @@ export const ItemRecordDetailPane: React.FC<IItemRecordDetailPane> = ({ itemReco
 
   const actionMenu = <Button bottomMargin0 buttonStyle='primary' onClick={noop}>{ t('button.actions') }</Button>;
 
-  if (!showDetail || !selectedItem) {
-    return null;
-  }
-
-  return (
-    <ErrorBoundary>
-      <Pane defaultWidth='fill' dismissible lastMenu={actionMenu} onClose={onClose} paneTitle={selectedItem?.name}>
+  return <Layer isOpen={showDetail}>
+    <Pane defaultWidth='fill' dismissible lastMenu={actionMenu} onClose={onClose} paneTitle={selectedItem?.name}>
+      <ErrorBoundary>
         <AccordionSet>
           <Accordion label={<FormattedMessage id='ui-workflow.workflows.detail.item.label' />} id={selectedItem?.id}>
             <Row>
@@ -60,7 +56,7 @@ export const ItemRecordDetailPane: React.FC<IItemRecordDetailPane> = ({ itemReco
             <NodesItemValue id='ui-workflow.workflows.label.nodes' value={selectedItem?.nodes} />
           </Accordion>
         </AccordionSet>
-      </Pane>
-    </ErrorBoundary>
-  );
+      </ErrorBoundary>
+    </Pane>
+  </Layer>;
 };

--- a/src/views/browse/BrowseView.tsx
+++ b/src/views/browse/BrowseView.tsx
@@ -2,7 +2,7 @@
 import type { FunctionComponent, useState } from 'react';
 import React from 'react';
 import { useLocalStorage } from '@rehooks/local-storage';
-import { Button, ErrorBoundary, Pane, Paneset, FilterPaneSearch, PaneHeader } from '@folio/stripes/components';
+import { Button, ErrorBoundary, Layer, Pane, Paneset, FilterPaneSearch, PaneHeader } from '@folio/stripes/components';
 import { useStripes } from '@folio/stripes/core';
 import { noop } from 'lodash';
 
@@ -29,31 +29,28 @@ export const BrowseView: FunctionComponent<IView> = (props: any) => {
   return (
     <ErrorBoundary>
       <Paneset>
-        <FilterPane
-          view={VIEW.BROWSE}
-          data={data}
-          isLoading={isLoading}
-          limit={limit}
-          offset={offset}
-          readFilters={filters}
-        />
-        <Pane
-          defaultWidth='fill'
-          paneTitle={t('title.workflowList')}
-          appIcon={<WorkflowIcon />}
-          firstMenu={<FilterMenu />}
-          lastMenu={<Button bottomMargin0 buttonStyle='primary' onClick={noop}>{ t('button.actions') }</Button>}
-        >
-          <ListTable
-            view={VIEW.BROWSE}
-            data={data}
-            isLoading={isLoading}
-            limit={limit}
-            offset={offset}
-            readFilters={filters}
-            detailPaneSelect={itemRecordDetail}
-          />
-        </Pane>
+        <Layer isOpen>
+          <Paneset isRoot>
+            <FilterPane view={VIEW.BROWSE} data={data} isLoading={isLoading} limit={limit} offset={offset} readFilters={filters} />
+            <Pane
+              defaultWidth='fill'
+              paneTitle={t('title.workflowList')}
+              appIcon={<WorkflowIcon />}
+              firstMenu={<FilterMenu />}
+              lastMenu={<Button bottomMargin0 buttonStyle='primary' onClick={noop}>{ t('button.actions') }</Button>}
+            >
+              <ListTable
+                view={VIEW.BROWSE}
+                data={data}
+                isLoading={isLoading}
+                limit={limit}
+                offset={offset}
+                readFilters={filters}
+                detailPaneSelect={itemRecordDetail}
+              />
+            </Pane>
+          </Paneset>
+        </Layer>
         <ItemRecordDetailPane itemRecordDetail={itemRecordDetail} view={VIEW.BROWSE} stripes={stripes} />
       </Paneset>
     </ErrorBoundary>


### PR DESCRIPTION
[UIWRKFLOW-13](https://folio-org.atlassian.net/browse/UIWRKFLOW-13)

Utilize a `Layer` to provide Workflow details as full screen. The other panes will be wrapped inside their own `Layer`.

The `Layer` `isOpen` property can be used to avoid the need to return NULL.

The `ErrorBoundary` is moved inside the `Pane` so that the error is more cleanly printed. If this becomes a problem then the error will need to be moved outside. There is still an outermost error message to catch any errors above that.