### PR TITLE
UIWRKFLOW-23: Ensure when there is no code that the '-' is showed.

### DIFF
--- a/src/components/common/ItemValues/CodeItemValue.tsx
+++ b/src/components/common/ItemValues/CodeItemValue.tsx
@@ -15,10 +15,8 @@ export const CodeItemValue: React.FC<IItemValue> = ({ control, format, empty, la
     return null;
   }
 
-  const text = typeof value === 'string'
-    ? raw
-      ? value
-      : value.length > 0 ? JSON.parse(value) : ''
+  const text = (typeof value === 'string' && value.length > 0)
+    ? raw ? value : JSON.parse(value)
     : undefined;
 
   if (!!text && text.length > BRIEF_CODE_SIZE) {
@@ -51,9 +49,11 @@ export const CodeItemValue: React.FC<IItemValue> = ({ control, format, empty, la
     </>;
   }
 
-  return <KeyValue label={ t(label) }>
-    <div className={ css?.codeItemValue }>
-      { !!text ? <code className={ css?.codeItemValueText }>{text}</code> : undefined }
-    </div>
-  </KeyValue>;
+  const markup = !!text
+    ? <div className={ css?.codeItemValue }>
+        <code className={ css?.codeItemValueText }>{text}</code>
+      </div>
+    : undefined;
+
+  return <KeyValue label={ t(label) }>{markup}</KeyValue>;
 };


### PR DESCRIPTION
[UIWRKFLOW-23](https://folio-org.atlassian.net/browse/UIWRKFLOW-23)

The standard FOLIO way of showing empty content in a `<KeyValue>` is to provide a dash. This is automatic if the `<KeyValue>` has no children. This is achieved through the use of `undefined`.

Rewrite the affected code to ensure that if the string is empty then the value is set to `undefined` rather than an empty string.

The wrapping `<div>` must also not be present when the `text` is `undefined`. Only render the `<div>` inside the `<KeyValue>` by passing `undefined` as the `markup` when the `text` is also `undefined`. When the `text` is defined, then the `markup` will wrap the `text` in a `<div>`.

This is what it looks like before this change (see the `MailMarkup` `<KeyValue>`).
![Screenshot_2024-08-16_15-12-01](https://github.com/user-attachments/assets/25a1f7cb-8cdd-411e-8052-5cee45be0f8e)


This is what it looks like after this change (see the `MailMarkup` `<KeyValue>`).
![Screenshot_2024-08-16_15-20-51](https://github.com/user-attachments/assets/a863f7b3-6204-47e7-9af5-37710a971a42)
