### PR TITLE
UIWRKFLOW-12: Fix incorrectly spelled permission and update labels.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       },
       {
         "permissionName": "settings.workflow.enabled",
-        "displayName": "Settings (workflow): display list of settings pages",
+        "displayName": "Settings (workflow): Display list of settings pages",
         "subPermissions": [
           "settings.enabled"
         ],
@@ -110,7 +110,7 @@
       },
       {
         "permissionName": "settings.workflow.configure",
-        "displayName": "Settings (workflow): Make changes to the workflow settings.",
+        "displayName": "Settings (workflow): Make changes to the workflow settings",
         "subPermissions": [
           "settings.enabled"
         ],
@@ -118,12 +118,12 @@
       },
       {
         "permissionName": "ui-workflow.all",
-        "displayName": "Full access to all UI-Workflow functionality.",
+        "displayName": "Workflow (Admin): All permissions",
         "subPermissions": [
           "workflow.actions.all",
           "workflow.events.all",
-          "workflow.triggers.all",
           "workflow.tasks.all",
+          "workflow.triggers.all",
           "workflow.workflows.all"
         ],
         "visible": true


### PR DESCRIPTION
[UIWRKFLOW-12](https://folio-org.atlassian.net/browse/UIWRKFLOW-12)

Update the permission name labels to be more consistent with some of the other FOLIO styles that I have observed.

The `ui-workflow.all` permissions name is preserved as is because this is the correct practice according to:
- https://github.com/folio-org/stripes-core/blob/4232e21277d44cd948486966e144bd4fb4abc0f1/doc/permissions.md#naming-permissions