### PR TITLE
UIWRKFLOW-18: Improve delete modal handling.

### DIFF
--- a/src/components/pane/ItemRecordGeneralPane/ItemRecordGeneralPane.tsx
+++ b/src/components/pane/ItemRecordGeneralPane/ItemRecordGeneralPane.tsx
@@ -16,7 +16,10 @@ export const ItemRecordGeneralPane: React.FC<IItemRecordPane> = ({ control, list
   const callout = useContext(CalloutContext);
   const deleteRequest = useDeleteRequest();
 
-  const deleteModal = useModal(null, () => { if (!!deleteControl.busy) deleteControl.onDone() });
+  const deleteModal = useModal(
+    () => deleteControl.setBusy(false),
+    () => { if (!!deleteControl.busy) deleteControl.onDone(); }
+  );
 
   const deleteControl = useClickControl(
     (onDone: any) => {
@@ -62,7 +65,9 @@ export const ItemRecordGeneralPane: React.FC<IItemRecordPane> = ({ control, list
           aria-label={ t('workflows.item.delete.modal.aria', { name: selected?.name }) }
           label={ t('workflows.item.delete.modal.label', { name: selected?.name }) }
           dismissible
+          closeOnBackgroundClick
           open={ deleteModal.show }
+          onOpen={ deleteModal.onShow }
           onClose={ deleteModal.onHide }
           footer={ deleteModalFooter }
         >

--- a/src/hooks/common/useModal/useModal.ts
+++ b/src/hooks/common/useModal/useModal.ts
@@ -20,7 +20,7 @@ export const useModal = (showCallback?: any, hideCallback?: any) => {
   const onHide = useCallback(() => {
     setShow(false);
 
-    if (!!showCallback) {
+    if (!!hideCallback) {
       hideCallback();
     }
   }, [ show ]);

--- a/src/hooks/control/useClickControl/useClickControl.ts
+++ b/src/hooks/control/useClickControl/useClickControl.ts
@@ -9,11 +9,11 @@ export const useClickControl = (clickCallback?: any, doneCallback?: any) => {
   const [ busy, setBusy ] = React.useState(false);
 
   const onDone = useCallback(() => {
-    if (busy) {
-      if (!!doneCallback) {
-        doneCallback();
-      }
+    if (!!doneCallback) {
+      doneCallback();
+    }
 
+    if (busy) {
       setBusy(false);
     }
   }, [ busy ]);


### PR DESCRIPTION
[UIWRKFLOW-18](https://folio-org.atlassian.net/browse/UIWRKFLOW-18)

Fix mistake where the `showCallback` is being used in the `useModal` when instead `hideCallback` should be used.

Relax the `onDone()` requirements for `busy` and set the state after the `doneCallback()` is called.

Utilize the `onShow` callback for `useModal` to reset the busy state to `false`. This is done because the Stripes Components Modal is not the actual close handler (see link below).

see: https://github.com/folio-org/stripes-components/blob/cb028f85dc89e39d516f4eec6131e7cfb1f5b983/lib/Modal/readme.md?plain=1#L32