### PR TITLE
UIWRKFLOW-31: Reduce flickering of the updated interface.

### DIFF
--- a/src/components/pane/ItemRecordDetailPane/ItemRecordDetailPane.tsx
+++ b/src/components/pane/ItemRecordDetailPane/ItemRecordDetailPane.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ErrorBoundary, Pane } from '@folio/stripes/components';
+import { ErrorBoundary, LoadingPane, Pane } from '@folio/stripes/components';
 
 import { IItemRecordPane } from '../../../interfaces';
 import { t } from '../../../utilities';
@@ -19,8 +19,13 @@ export const ItemRecordDetailPane: React.FC<IItemRecordPane> = (props?: any) => 
     : t('title.itemRecordDetailPane');
   const onClose = !!props.control.detailControl?.onClose ? props.control.detailControl.onClose : false;
 
-  return <Pane id={ props?.id } defaultWidth='fill' dismissible onClose={onClose} paneTitle={paneTitle}>
+  const loadingPane = (props?.workflow?.isLoading)
+    ? <LoadingPane />
+    : null;
+
+  return <Pane id={ props?.id } defaultWidth='30%' dismissible onClose={onClose} paneTitle={paneTitle}>
     <ErrorBoundary>
+      {loadingPane}
       <ItemRecordDetailView { ...props } />
     </ErrorBoundary>
   </Pane>;

--- a/src/components/pane/ItemRecordGeneralPane/ItemRecordGeneralPane.tsx
+++ b/src/components/pane/ItemRecordGeneralPane/ItemRecordGeneralPane.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { Accordion, AccordionSet, Button, Col, ErrorBoundary, Modal, ModalFooter, Pane, Row } from '@folio/stripes/components';
+import { Accordion, AccordionSet, Button, Col, ErrorBoundary, LoadingPane, Modal, ModalFooter, Pane, Row } from '@folio/stripes/components';
 import { CalloutContext } from '@folio/stripes/core';
 
 import { useClickControl, useDeleteRequest, useModal } from '../../../hooks';
@@ -58,8 +58,13 @@ export const ItemRecordGeneralPane: React.FC<IItemRecordPane> = ({ control, stri
     <Button onClick={ deleteModal.onHide }>{ t('button.workflows.item.delete.cancel') }</Button>
   </ModalFooter>;
 
-  return <Pane id={id} defaultWidth='fill' dismissible onClose={closeWorkflowPane} paneTitle={ t('title.itemRecordGeneralPane') } lastMenu={actionMenu}>
+  const loadingPane = (workflow?.isLoading)
+    ? <LoadingPane />
+    : null;
+
+  return <Pane id={id} defaultWidth='30%' dismissible onClose={closeWorkflowPane} paneTitle={ t('title.itemRecordGeneralPane') } lastMenu={actionMenu}>
     <ErrorBoundary>
+      {loadingPane}
       <Modal
         aria-label={ t('workflows.item.delete.modal.aria', { name: selected?.name }) }
         label={ t('workflows.item.delete.modal.label', { name: selected?.name }) }

--- a/src/components/pane/ItemRecordGraphPane/ItemRecordGraphPane.tsx
+++ b/src/components/pane/ItemRecordGraphPane/ItemRecordGraphPane.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ErrorBoundary, Pane } from '@folio/stripes/components';
+import { ErrorBoundary, LoadingPane, Pane } from '@folio/stripes/components';
 
 import { GraphsItemValue } from '../../../components';
 import { IItemRecordPane } from '../../../interfaces';
@@ -15,9 +15,13 @@ export const ItemRecordGraphPane: React.FC<IItemRecordPane> = ({ control, id, wo
 
   const selected = workflow?.data;
   const paneTitle = selected?.name ? selected.name : t('title.itemRecordGraphPane');
+  const loadingPane = (workflow?.isLoading)
+    ? <LoadingPane />
+    : null;
 
-  return <Pane id={id} defaultWidth='fill' paneTitle={paneTitle}>
+  return <Pane id={id} defaultWidth='70%' paneTitle={paneTitle}>
     <ErrorBoundary>
+      {loadingPane}
       <GraphsItemValue label='workflows.label.graphs' value={ selected?.nodes } onSelect={ control?.onNodeClick } selected={selected} />
     </ErrorBoundary>
   </Pane>;

--- a/src/views/detail/DetailView.tsx
+++ b/src/views/detail/DetailView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LoadingPane, Paneset } from '@folio/stripes/components';
+import { Paneset } from '@folio/stripes/components';
 import { useStripes } from '@folio/stripes/core';
 
 import { BACKEND_PATH, VIEW } from '../../constants';
@@ -24,10 +24,6 @@ export const DetailView: React.FC = (props?: any) => {
     view: VIEW.DETAIL,
     workflow,
   };
-
-  if (workflow?.isLoading) {
-    return <LoadingPane />;
-  }
 
   const layouts = [
     {


### PR DESCRIPTION
[UIWRKFLOW-31](https://folio-org.atlassian.net/browse/UIWRKFLOW-31)

- Make sure the `defaultWidth` matches the `initialLayout` values.
- Move the `LoadingPane` inside each of the Panes to ensure the Panes are always loaded.

Having a `LoadingPane` within each `Pane` might be excessive but that can be determined at a later time upon review.