### PR TITLE
UIWRKFLOW-37: The stripes-acq-components needs typings to properly build and serve under Typescript.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@folio/stripes": "^9.0.0",
+    "@folio/stripes-acq-components": "^5.0.0",
     "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-components": "^12.0.0",
     "@folio/stripes-connect": "^9.0.0",

--- a/typings/stripes-acq-components.d.ts
+++ b/typings/stripes-acq-components.d.ts
@@ -1,0 +1,1 @@
+declare module '@folio/stripes-acq-components';


### PR DESCRIPTION
Resolves [UIWRKFLOW-37](https://folio-org.atlassian.net/browse/UIWRKFLOW-37).

Recent builds are showing the `stripes-acq-components` failing on some dependencies. The cause is that the Javascript is not exporting things in ways that Typescript wants.

Add the `stripes-acq-components` as an explicit `typings` file. The `stripes-acq-components` must also be added during development stage to get this to work properly.

The error messages that should be fixed by this look like:
```
ERROR in C:\...\workflow\node_modules\@folio\workflow\src\components\table\WorkflowListTable\WorkflowListTable.tsx
6:9-27
[tsl] ERROR in C:\...\workflow\node_modules\@folio\workflow\src\components\table\WorkflowListTable\WorkflowListTable.tsx(6,10)
      TS2305: Module '"@folio/stripes-acq-components"' has no exported member 'PrevNextPagination'.
ERROR in C:\...\workflow\node_modules\@folio\workflow\src\components\table\WorkflowListTable\WorkflowListTable.tsx
6:29-42
[tsl] ERROR in C:\...\workflow\node_modules\@folio\workflow\src\components\table\WorkflowListTable\WorkflowListTable.tsx(6,30)
      TS2305: Module '"@folio/stripes-acq-components"' has no exported member 'usePagination'.
ERROR in C:\...\workflow\ui-workflow\src\components\table\WorkflowListTable\WorkflowListTable.tsx
./src/components/table/WorkflowListTable/WorkflowListTable.tsx 6:9-27
```