### PR TITLE
UIWRKFLOW-39: Get things working at least under Quesnelia.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@folio/stripes": "^9.0.0",
-    "@folio/stripes-acq-components": "^5.0.0",
+    "@folio/stripes-acq-components": "^5.1.0",
     "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-components": "^12.0.0",
     "@folio/stripes-connect": "^9.0.0",
@@ -29,7 +29,7 @@
     "@folio/stripes-final-form": "^8.0.0",
     "@folio/stripes-form": "^9.0.0",
     "@folio/stripes-logger": "^1.0.0",
-    "@folio/stripes-smart-components": "^9.0.0",
+    "@folio/stripes-smart-components": "^9.1.0",
     "@folio/stripes-types": "^2.1.0",
     "@folio/stripes-util": "^6.0.0",
     "@rehooks/local-storage": "^2.4.0",
@@ -45,7 +45,7 @@
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-junit": "^12.0.0",
-    "ky": "^1.3.0",
+    "ky": "^0.31.0",
     "lodash": "^4.17.0",
     "miragejs": "^0.1.0",
     "moment": "^2.29.0",
@@ -63,7 +63,6 @@
     "ts-jest": "^29.1.0"
   },
   "dependencies": {
-    "@folio/stripes-acq-components": "^5.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
@@ -140,6 +139,5 @@
     ]
   },
   "resolutions": {
-    "@folio/stripes-types": "^2.1.0"
   }
 }

--- a/src/settings/workflows/WorkflowsSettings.tsx
+++ b/src/settings/workflows/WorkflowsSettings.tsx
@@ -3,11 +3,11 @@ import type { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl';
 
 import { stripesConnect } from '@folio/stripes/core';
-import { ConfigManager as UnconnectedConfigManager } from '@folio/stripes/smart-components';
+import { ConfigManager } from '@folio/stripes/smart-components';
 
 import { WorkflowsSettingsForm } from './WorkflowsSettingsForm';
 
-const ConfigManager = stripesConnect(UnconnectedConfigManager);
+const ConnectedConfigManager = stripesConnect(ConfigManager);
 
 export const WorkflowsSettings: FunctionComponent = () => {
   const getInitialValues = (settings: any) => {
@@ -16,7 +16,7 @@ export const WorkflowsSettings: FunctionComponent = () => {
   }
 
   return (
-    <ConfigManager
+    <ConnectedConfigManager
       configFormComponent={WorkflowsSettingsForm}
       configName="workflows"
       getInitialValues={getInitialValues}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,13 +21,14 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src", "**/*.ts", "**/*.tsx"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ],
   "exclude": [
-   "node_modules",
-   "**/*.spec.ts",
-   "**/*.spec.tsx",
-   "**/*.test.ts",
-   "**/*.test.tsx"
+    "node_modules",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
This relates to [UIWRKFLOW-39](https://folio-org.atlassian.net/browse/UIWRKFLOW-39) but does not solve it.

Instead, this gets a step closer to getting Poppy to work by at least getting this project to build under Quesnelia.

This has been tested under `R1-2024-csp-5` tag from [platform-complete](https://github.com/folio-org/platform-complete), by using a local build like this.

Edit `package.json` from `platform-complete` to point to a local `ui-workflow`:
```json
    "@folio/workflow": "file:../workspace/ui-workflow",
```

Edit the `stripes.config.js` from `platform-complete` to include `ui-workflow`:
```json
    '@folio/workflow': {},
```

Install and build `platform-complete`:
```sh
yarn install && yarn build
```

Poppy is not currently working due to dependency problems.
The Poppy build might have to have changes to the dependencies which might break other projects.

The ui-workflow project appears to require at minimum the following:
```
  "@folio/stripes-acq-components": "^5.1.0"
  "@folio/stripes-smart-components": "^9.1.0"
  "ky": "^0.31.0"
```

Remove the dependencies and resolutions that are not needed anymore.

There are dependency poblems with `ConfigManager` in Poppy.
Change the use of `UnconnectedConfigManager` to instead use `ConnectedConfigManager`.
This might help make the dependency navigation less confusing about avoiding renaming an import.
The variable is instead renamed rather than the import.

Fix the `tsconfig.json` tabbing.
Fix the include and exclude dependencies in `tsconfig.json` to reduce what is being brought in.
