### PR TITLE
Get the unit tests working again.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ stripes serve --okapi http://my-okapi.example.com:9130 --tenant my-tenant-id
 
 Run the included UI tests with the following command:
 ```
-stripes test karma
+yarn test
 ```
+
+This will generate coverage reports at `artifacts/coverage-jest/`.
+A user may view the resulting coverage reports by pointing their browser to `artifacts/coverage-jest/lcov-report/index.html`.
 
 ### Issue tracker
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', {targets: {node: 'current'}}],
+    [ '@babel/preset-env', { targets: { node: 'current' }, esmodules: true } ],
+    [ '@babel/preset-react', { runtime: 'automatic' } ],
     '@babel/preset-typescript',
   ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,12 +9,11 @@ module.exports = {
     '<rootDir>/src/**/*.{ts,tsx}',
     '!<rootDir>/**/node_modules/**',
     '!<rootDir>/**/test/jest/**',
+    '!<rootDir>/**/index.ts'
   ],
   coverageDirectory: './artifacts/coverage-jest/',
   coverageReporters: ['lcov'],
-  coveragePathIgnorePatterns: [
-    "/node_modules/"
-  ],
+  coveragePathIgnorePatterns: ['/node_modules/'],
   coverageProvider: "babel",
   reporters: [ 'jest-junit', 'default' ],
   transform: {
@@ -29,8 +28,6 @@ module.exports = {
   moduleDirectories: [ 'node_modules', '<rootDir>' ],
   testMatch: [ '<rootDir>/src/**/?(*.)test.{ts,tsx}' ],
   testPathIgnorePatterns: ['/node_modules'],
-  setupFiles: [
-    './test/jest/setupTests.ts'
-  ],
+  setupFiles: ['./test/jest/setupTests.ts'],
   setupFilesAfterEnv: [ '<rootDir>/test/jest/jest.setup.ts' ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,8 +26,8 @@ module.exports = {
     '^.+\\.(css|svg)$': 'identity-obj-proxy',
   },
   moduleDirectories: [ 'node_modules', '<rootDir>' ],
-  testMatch: [ '<rootDir>/src/**/?(*.)test.{ts,tsx}' ],
+  testMatch: ['<rootDir>/src/**/?(*.)test.{ts,tsx}'],
   testPathIgnorePatterns: ['/node_modules'],
   setupFiles: ['./test/jest/setupTests.ts'],
-  setupFilesAfterEnv: [ '<rootDir>/test/jest/jest.setup.ts' ],
+  setupFilesAfterEnv: ['<rootDir>/test/jest/jest.setup.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,32 +1,36 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-const path = require('path');
-
 const esModules = ['@folio', 'ky'].join('|');
 
 module.exports = {
   testEnvironment: 'jsdom',
   preset: 'ts-jest',
+  clearMocks: true,
+  collectCoverage: true,
   collectCoverageFrom: [
-    '**/(lib|src)/**/*.{ts,tsx}',
-    '!**/node_modules/**',
-    '!**/test/jest/**',
+    '<rootDir>/src/**/*.{ts,tsx}',
+    '!<rootDir>/**/node_modules/**',
+    '!<rootDir>/**/test/jest/**',
   ],
   coverageDirectory: './artifacts/coverage-jest/',
   coverageReporters: ['lcov'],
-  reporters: ['jest-junit', 'default'],
+  coveragePathIgnorePatterns: [
+    "/node_modules/"
+  ],
+  coverageProvider: "babel",
+  reporters: [ 'jest-junit', 'default' ],
   transform: {
     '^.+\\.(t|j)sx?$': 'ts-jest',
   },
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
-  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
+  maxWorkers: "50%",
+  moduleFileExtensions: [ 'js', 'jsx', 'ts', 'tsx', 'json' ],
   moduleNameMapper: {
     '^.+\\.(css|svg)$': 'identity-obj-proxy',
   },
-  moduleDirectories: ['node_modules', '<rootDir>'],
-  testMatch: ['**/(lib|src)/**/?(*.)test.{ts,tsx}'],
-  testPathIgnorePatterns: ['/node_modules/'],
+  moduleDirectories: [ 'node_modules', '<rootDir>' ],
+  testMatch: [ '<rootDir>/src/**/?(*.)test.{ts,tsx}' ],
+  testPathIgnorePatterns: ['/node_modules'],
   setupFiles: [
-    path.join(__dirname, './test/jest/setupTests.ts')
+    './test/jest/setupTests.ts'
   ],
-  setupFilesAfterEnv: [path.join(__dirname, './test/jest/jest.setup.ts')],
+  setupFilesAfterEnv: [ '<rootDir>/test/jest/jest.setup.ts' ],
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "start": "stripes serve",
@@ -20,6 +20,9 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.0",
+    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-react": "^7.25.9",
+    "@babel/preset-typescript": "^7.26.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-acq-components": "^5.1.0",
@@ -55,7 +58,6 @@
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-junit": "^12.0.0",
-    "ky": "^0.31.0",
     "lodash": "^4.17.0",
     "miragejs": "^0.1.0",
     "moment": "^2.29.0",

--- a/src/components/table/WorkflowListTable/WorkflowListTable.tsx
+++ b/src/components/table/WorkflowListTable/WorkflowListTable.tsx
@@ -5,7 +5,7 @@ import { useLocalStorage, writeStorage } from '@rehooks/local-storage';
 import { Loading, LoadingPane, MultiColumnList, Row } from '@folio/stripes/components';
 import { PrevNextPagination, usePagination } from '@folio/stripes-acq-components';
 
-import { ITEMS_VISIBLE_COLUMNS, ITEMS_COLUMN_WIDTHS, CURRENT_PAGE_OFFSET_KEY, UI_PATH, VIEW } from '../../../constants';
+import { CURRENT_PAGE_OFFSET_KEY, ITEMS_VISIBLE_COLUMNS, ITEMS_COLUMN_WIDTHS, PAGINATION_AMOUNT, UI_PATH, VIEW } from '../../../constants';
 import { usePrevious, useWorkflowListTable } from '../../../hooks';
 import { IItemRecord, IListProperties } from '../../../interfaces';
 import { listTableMapping, listTableResultFormatter } from './helpers';
@@ -13,7 +13,7 @@ import { listTableMapping, listTableResultFormatter } from './helpers';
 /**
  * A table consisting of the Workflow Item Records.
  */
-export const WorkflowListTable: React.FC<IListProperties> = ({ filters, limit, list, offset, path }) => {
+export const WorkflowListTable: React.FC<IListProperties> = ({ filters, limit = PAGINATION_AMOUNT, list, offset = 0, path }) => {
   const navigate = useHistory();
   const pagination = usePagination({ limit, offset });
   const prevFilters = usePrevious(filters);

--- a/src/hooks/network/useSearch/useSearch.test.ts
+++ b/src/hooks/network/useSearch/useSearch.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-import { SearchField } from '@folio/stripes/components';
 
 import { ITEM_COLUMNS_NAME, VIEW } from '../../../constants';
 import { useSearch } from '.';

--- a/src/hooks/network/useSearch/useSearch.test.ts
+++ b/src/hooks/network/useSearch/useSearch.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { SearchField } from '@folio/stripes/components';
 
 import { ITEM_COLUMNS_NAME, VIEW } from '../../../constants';
 import { useSearch } from '.';
@@ -6,9 +7,14 @@ import { useSearch } from '.';
 describe('useSearch', () => {
   describe('When initial render happened', () => {
     const { result } = renderHook(() => useSearch(VIEW.NAME, ITEM_COLUMNS_NAME.NAME));
+    const search = result.current;
 
     it('is expected to return defined', () => {
-      expect(result.current).toBeDefined();
+      expect(search).toBeDefined();
+    });
+
+    it('isDefaultState() returns true', () => {
+      expect(search.isDefaultState()).toEqual(true);
     });
   });
 });

--- a/src/hooks/network/useUpload/useUploadMultipart.test.ts
+++ b/src/hooks/network/useUpload/useUploadMultipart.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { Response, Server } from 'miragejs';
 
 import { OKAPI_WORKFLOW_IMPORT } from '../../../constants';

--- a/src/hooks/storage/useLocalStorageToggle/useLocalStorageToggle.test.ts
+++ b/src/hooks/storage/useLocalStorageToggle/useLocalStorageToggle.test.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
-import { beforeEach } from '@jest/globals';
 
 import { useLocalStorageToggle } from '.';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
   },
   "include": [
     "src/**/*.ts",
-    "src/**/*.tsx"
+    "src/**/*.tsx",
+    "typings/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
There are still a lot of unknowns and Jest is very fickle.
Writing tests may be difficult using Jest with Typescript and the TSX files.

Add the typings to the `tsconfig.json` fixes some of the problems.
Add and enabled additional dependencies.

Tweak the `jest.config.js` until the tests work.
The unit tests reported problems about potentially undefined variables `limit` and `offset`.
Add sane defaults.

Use `<rootDir>` rather than importing `const path = require('path');`.
The use of `require` is reported as a problem and caused compile problems.

The coverage is now enabled and a report is now generated.
The `artifacts/coverage-jest/` has the generated `lcov` report.
Point a webbrowser to `artifacts/coverage-jest/lcov-report/index.html` to view the current coverage.

Remove deprecated `renderHook` import.
