### PR TITLE
UIWRKFLOW-52: Boolean is always false due to improper string typeof check.

### DIFF
--- a/src/utilities/common/truthy/truthy.ts
+++ b/src/utilities/common/truthy/truthy.ts
@@ -9,10 +9,17 @@
  * @return TRUE on true value and FALSE otherwise.
  */
 export const isFolioTruthy = (value: any): boolean => {
-  const strValue = typeof value === 'string' ? value.toLowerCase() : null;
+  const strValue = typeof value === 'string' ? value.toLowerCase().trim() : null;
 
-  if (strValue === null || value === false) return false;
-  if (typeof value === 'number' && value !== 0) return true;
+  if (typeof value === 'boolean') {
+    return value;
+  }
 
-  return value === true || strValue === 'true' || strValue === 't' || strValue === 'yes';
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (value === null || typeof value !== 'string') return false;
+
+  return strValue === 'true' || strValue === 't' || strValue === 'yes';
 };


### PR DESCRIPTION
Resolves [UIWRKFLOW-52](https://folio-org.atlassian.net/browse/UIWRKFLOW-52) .

The `strValue === null` code must only trigger when the type of the value is a string.

Also add explicit boolean check and pass booleans through as-is.